### PR TITLE
Parks path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@
 /yarn-error.log
 
 .byebug_history
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'figaro'
 
 group :development, :test do
   gem 'pry'
+  gem 'dotenv-rails'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,10 @@ GEM
     crass (1.0.6)
     diff-lcs (1.4.4)
     docile (1.3.2)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.9.0)
     execjs (2.7.0)
     faraday (1.0.1)
@@ -215,6 +219,7 @@ DEPENDENCIES
   bootsnap
   capybara
   coffee-rails (~> 4.2)
+  dotenv-rails
   faraday
   figaro
   jbuilder (~> 2.5)

--- a/app/controllers/parks_controller.rb
+++ b/app/controllers/parks_controller.rb
@@ -1,5 +1,12 @@
 class ParksController < ApplicationController
   def index
-    require "pry"; binding.pry
+    response = self.connection.get("parks?stateCode=#{params['state']}&api_key=#{ENV['PARKS_API_KEY']}")
+    @parsed = JSON.parse(response.body)
+  end
+
+  def connection
+    Faraday.new(
+      url: 'https://developer.nps.gov/api/v1/'
+    )
   end
 end

--- a/app/views/parks/index.html.erb
+++ b/app/views/parks/index.html.erb
@@ -1,0 +1,15 @@
+<h2><%= "#{@parsed['total']} Total National Parks in #{params['state']}" %></h2>
+<% @parsed['data'].each do |park|%>
+<p>
+  <b>Park Name:</b> <br>
+  <%= park['fullName'] %> <br>
+  <b>Description:</b><br>
+  <%= park['description'] %> <br>
+  <b> Directions:</b> <br>
+  <%= park['directionsInfo'] %> <br>
+  <b>Hours of Operation:</b><br>
+  <% park['operatingHours'].first['standardHours'].to_a.each do |day, time| %>
+    <%= day.capitalize + ": " + time %> <br>
+  <% end %>
+</p>
+<% end %>


### PR DESCRIPTION
Create parks_controller index and connection methods. Hits API endpoint for NPS parks filtered by state.
Create Parks view that renders:
Total count of parks in the state
Each parks name, description, hours of operation, and directions. Simple rendering, no styling.
